### PR TITLE
[WIP] adding verbose option

### DIFF
--- a/lib/stock_calculator.rb
+++ b/lib/stock_calculator.rb
@@ -7,8 +7,31 @@ module StockCalculator
   require 'stock_calculator/notifier'
 
   class << self
-    def run(stock_symbol:, start_date:)
-      Main.new(stock_symbol: stock_symbol, start_date: start_date).notify
+    def run(stock_symbol:, start_date:, verbose: false)
+      main = Main.new(stock_symbol: stock_symbol, start_date: start_date)
+      if verbose
+        puts '=' * 5 + 'verbose' + '=' * 5
+        main.result.price_datas.each do |price_data|
+          puts "ticker: #{price_data.ticker}"
+          puts "date: #{price_data.date}"
+          puts "open: #{price_data.open.to_f}"
+          puts "high: #{price_data.high.to_f}"
+          puts "low: #{price_data.low.to_f}"
+          puts "close: #{price_data.close.to_f}"
+          puts "volume: #{price_data.volume.to_f}"
+          puts "ex_dividend: #{price_data.ex_dividend.to_f}"
+          puts "split_ratio: #{price_data.split_ratio.to_f}"
+          puts "adj_open: #{price_data.adj_open.to_f}"
+          puts "adj_high: #{price_data.adj_high.to_f}"
+          puts "adj_low: #{price_data.adj_low.to_f}"
+          puts "adj_close: #{price_data.adj_close.to_f}"
+          puts "adj_volume: #{price_data.adj_volume.to_f}"
+          puts
+        end
+        puts '=' * 5 + 'verbose' + '=' * 5
+        puts
+      end
+      main.notify
     end
   end
 

--- a/lib/stock_calculator/cli.rb
+++ b/lib/stock_calculator/cli.rb
@@ -3,8 +3,15 @@ module StockCalculator
 
   class Cli < ::Thor
     desc 'execute STOCK_SYMBOL START_DATE', 'calculate rate of return, maximum drawdown and notify result'
+    options verbose: :boolean
     def execute(stock_symbol, start_date)
-      StockCalculator.run(stock_symbol: stock_symbol, start_date: start_date)
+      StockCalculator.run(
+        {
+          stock_symbol: stock_symbol,
+          start_date: start_date,
+          verbose: options[:verbose]
+        }.compact
+      )
 
     # Input
     rescue StockCalculator::InvalidDate


### PR DESCRIPTION
```
 $ stock_calculator execute AAPL 2017-12-05 --verbose
=====verbose=====
ticker: AAPL
date: 2017-12-05
open: 169.06
high: 171.52
low: 168.4
close: 169.64
volume: 27008428.0
ex_dividend: 0.0
split_ratio: 1.0
adj_open: 169.06
adj_high: 171.52
adj_low: 168.4
adj_close: 169.64
adj_volume: 27008428.0

ticker: AAPL
date: 2017-12-06
open: 167.5
high: 170.2047
low: 166.46
close: 169.01
volume: 28224357.0
ex_dividend: 0.0
split_ratio: 1.0
adj_open: 167.5
adj_high: 170.2047
adj_low: 166.46
adj_close: 169.01
adj_volume: 28224357.0

=====verbose=====

Stock Symbol: AAPL
Date: 2017-12-05 ~ 2017-12-07

Rate of return: -0.03%
Maximum Drawdown: 2.95%
Notified to Slack!
```

## TODO:
 - [ ] write integration test
 - [ ] adding alias of verbose `--v`
 - [ ] write document
